### PR TITLE
Feat: promo de bienvenida + atribucion en ofertas + fixes varios

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -38,6 +38,7 @@ import { ConsentRecord } from 'src/repository/legal/consent-record.entity';
 import { AccountDeletionLog } from 'src/repository/legal/account-deletion-log.entity';
 import { Bug } from 'src/repository/bug/bug.entity';
 import { SystemAlert } from 'src/repository/system-alert/system-alert.entity';
+import { Promocion } from 'src/repository/promocion/promocion.entity';
 
 // Cargar variables de entorno
 dotenv.config();
@@ -51,7 +52,7 @@ export const databaseConfig: TypeOrmModuleOptions = {
     database: process.env.DB_NAME || 'tuempleo',
     entities: [Registro, Rol, Usuario, Postulante,
         Curriculum, Planes, Empresa, Empleador, Oferta, Postulacion,
-        Transaction, ShoppingCart, ProcesoSeleccion, TrabajoGuardado, CompanyReview, EmployerPlanLedger, OfferPolicy, TransactionItem, Stock, PaymentIntent, CountVisit, CuposUsados, StockGratis, Sms, Region, Comuna, WorkArea, InstitucionEducacional, BusinessActivity, Mail, AlertaEmpleo, InvitacionEmpleador, LegalDocument, ConsentRecord, AccountDeletionLog, Bug, SystemAlert],
+        Transaction, ShoppingCart, ProcesoSeleccion, TrabajoGuardado, CompanyReview, EmployerPlanLedger, OfferPolicy, TransactionItem, Stock, PaymentIntent, CountVisit, CuposUsados, StockGratis, Sms, Region, Comuna, WorkArea, InstitucionEducacional, BusinessActivity, Mail, AlertaEmpleo, InvitacionEmpleador, LegalDocument, ConsentRecord, AccountDeletionLog, Bug, SystemAlert, Promocion],
     // logging: true,
     synchronize: process.env.DB_SYNCHRONIZE === 'false',
 

--- a/src/modules/business/business.module.ts
+++ b/src/modules/business/business.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EmpresaController } from './business.controller';
 import { EmpresaService } from './business.service';
 import { Empresa } from '../../repository/business/business.entity';
+import { PromocionModule } from '../promocion/promocion.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Empresa])],
+    imports: [TypeOrmModule.forFeature([Empresa]), PromocionModule],
     controllers: [EmpresaController],
     providers: [EmpresaService],
     exports: [EmpresaService],

--- a/src/modules/business/business.service.ts
+++ b/src/modules/business/business.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Empresa } from "../../repository/business/business.entity";
 import { CreateBusinessDto } from "./dto/create-business.dto";
+import { PromocionService } from "../promocion/promocion.service";
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -11,6 +12,7 @@ export class EmpresaService {
     constructor(
         @InjectRepository(Empresa)
         private readonly businessRepository: Repository<Empresa>,
+        private readonly promocionService: PromocionService,
     ) { }
 
     public async getAllBusinesses(): Promise<Empresa[]> {
@@ -40,8 +42,7 @@ export class EmpresaService {
         };
     }
 
-    public createBusiness(createBusinessDto: CreateBusinessDto): Promise<Empresa> {
-
+    public async createBusiness(createBusinessDto: CreateBusinessDto): Promise<Empresa> {
 
         // Aquí creamos la entidad Empresa con plan como objeto { id: planId }
         const business = this.businessRepository.create({
@@ -50,7 +51,12 @@ export class EmpresaService {
             data: createBusinessDto.data,  // data es JSON y viene en DTO
         });
 
-        return this.businessRepository.save(business);
+        const saved = await this.businessRepository.save(business);
+
+        // 🎁 Regalo de bienvenida: 3 avisos PREMIUM por 30 días (idempotente)
+        await this.promocionService.otorgarBienvenida(saved.id);
+
+        return saved;
     }
 
     public async uploadBusinessLogo(rut: string, file: Express.Multer.File): Promise<Empresa> {

--- a/src/modules/business/dto/create-business.dto.ts
+++ b/src/modules/business/dto/create-business.dto.ts
@@ -7,6 +7,7 @@ import {
     IsOptional,
     IsNumber,
     IsString,
+    Matches,
 } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 
@@ -54,9 +55,10 @@ export class BusinessDataDto {
     @IsString()
     pais: string;
 
-    @ApiProperty({ example: '+56912345678' })
+    @ApiProperty({ example: '+56988440465' })
     @IsNotEmpty()
     @IsString()
+    @Matches(/^\+56\d{9}$/, { message: 'telefono debe tener formato +56XXXXXXXXX (12 caracteres)' })
     telefono: string;
 
     @ApiProperty({ example: 'Empresa dedicada a servicios tecnológicos' })

--- a/src/modules/business/dto/update-business.dto.ts
+++ b/src/modules/business/dto/update-business.dto.ts
@@ -3,6 +3,7 @@ import {
     IsString,
     IsArray,
     IsUrl,
+    Matches,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -12,9 +13,10 @@ export class UpdateBusinessDto {
     @IsString()
     nombre_fantasia?: string;
 
-    @ApiProperty({ example: '+56912345678', required: false })
+    @ApiProperty({ example: '+56988440465', required: false })
     @IsOptional()
     @IsString()
+    @Matches(/^\+56\d{9}$/, { message: 'telefono debe tener formato +56XXXXXXXXX (12 caracteres)' })
     telefono?: string;
 
     @ApiProperty({ type: [String], example: ['Av. Providencia 123'], required: false })

--- a/src/modules/employer/dto/create-employer.dto.ts
+++ b/src/modules/employer/dto/create-employer.dto.ts
@@ -1,7 +1,7 @@
 // src/modules/forms/dto/create-employer.dto.ts
 
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, Matches, ValidateNested } from 'class-validator';
 
 export class EmployerDataDto {
 
@@ -27,6 +27,7 @@ export class EmployerDataDto {
 
     @IsNotEmpty()
     @IsString()
+    @Matches(/^\+56\d{9}$/, { message: 'telefono debe tener formato +56XXXXXXXXX (12 caracteres)' })
     telefono: string;
 
     @IsOptional()

--- a/src/modules/oauth/oauth.controller.ts
+++ b/src/modules/oauth/oauth.controller.ts
@@ -29,6 +29,8 @@ export class OauthController {
     const allowList = new Set<string>([
       'https://tuempleo.cl',
       'https://www.tuempleo.cl',
+      'https://tuvacante.com',
+      'https://www.tuvacante.com',
     ])
 
     const envList = (process.env.OAUTH_ALLOWED_ORIGINS || '')
@@ -40,6 +42,7 @@ export class OauthController {
 
     const regexes = [
       /^https?:\/\/([a-z0-9-]+\.)*tuempleo\.cl(?::\d+)?$/i,
+      /^https?:\/\/([a-z0-9-]+\.)*tuvacante\.com(?::\d+)?$/i,
       /^http:\/\/(localhost|127\.0\.0\.1)(?::\d+)?$/i,
       /^https:\/\/(localhost|127\.0\.0\.1)(?::\d+)?$/i,
     ]

--- a/src/modules/oferta/oferta.service.ts
+++ b/src/modules/oferta/oferta.service.ts
@@ -238,6 +238,7 @@ export class OfertaService {
       throw new NotFoundException(`Empresa con ID ${data.empresa_id} no encontrada`);
 
     // 3️⃣ Verificar crédito o stock gratis
+    let promocionUsada: Awaited<ReturnType<typeof this.StockService.useCredit>>['promocion'] = null;
     if (data.tipo_aviso === 'GRATIS') {
       const result = await this.freeStockService.useMonthlyFreeStock(data.empresa_id);
 
@@ -245,10 +246,11 @@ export class OfertaService {
         throw new BadRequestException(result.mensaje);
       }
     } else {
-      await this.StockService.useCredit(
+      const { promocion } = await this.StockService.useCredit(
         data.empresa_id,
         data.tipo_aviso as 'BASICO' | 'ESTANDAR' | 'PREMIUM'
       );
+      promocionUsada = promocion;
     }
 
     // 4️⃣ Calcular fechas
@@ -276,6 +278,7 @@ export class OfertaService {
       estado: esGratis ? 'pendiente_revision' : 'publicada',
       data: JSON.stringify(data.data),
       priority: prioridad,
+      promocion: promocionUsada,
     };
 
     const oferta = this.ofertaRepository.create(nuevaOferta);
@@ -558,10 +561,12 @@ export class OfertaService {
         throw new BadRequestException(result.mensaje);
       }
     } else {
-      await this.StockService.useCredit(
+      const { promocion } = await this.StockService.useCredit(
         oferta.empresa.id,
         oferta.tipo_aviso as 'BASICO' | 'ESTANDAR' | 'PREMIUM',
       );
+      // Si el nuevo crédito vino de una promo (o no), actualizamos la atribución.
+      oferta.promocion = promocion;
     }
 
     // Republicar como nueva: resetear fechas y estado

--- a/src/modules/postulant/dto/create-postulant.dto.ts
+++ b/src/modules/postulant/dto/create-postulant.dto.ts
@@ -4,6 +4,7 @@ import {
   IsNumber,
   IsOptional,
   IsString,
+  Matches,
   ValidateNested,
 } from 'class-validator';
 
@@ -26,6 +27,7 @@ class DatosPersonalesDto {
   region: string;
 
   @IsString()
+  @Matches(/^\+56\d{9}$/, { message: 'telefono debe tener formato +56XXXXXXXXX (12 caracteres)' })
   telefono: string;
 
   @IsString()

--- a/src/modules/promocion/promocion.module.ts
+++ b/src/modules/promocion/promocion.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Promocion } from 'src/repository/promocion/promocion.entity';
+import { PromocionService } from './promocion.service';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([Promocion])],
+    providers: [PromocionService],
+    exports: [PromocionService],
+})
+export class PromocionModule { }

--- a/src/modules/promocion/promocion.service.ts
+++ b/src/modules/promocion/promocion.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, MoreThan, Repository } from 'typeorm';
+import { Promocion } from 'src/repository/promocion/promocion.entity';
+
+const DIAS_BIENVENIDA = 30;
+const CANTIDAD_BIENVENIDA = 3;
+const TIPO_BIENVENIDA: 'PREMIUM' = 'PREMIUM';
+
+@Injectable()
+export class PromocionService {
+    constructor(
+        @InjectRepository(Promocion)
+        private readonly promoRepo: Repository<Promocion>,
+    ) { }
+
+    /**
+     * 🎁 Regalo de bienvenida: 3 avisos PREMIUM por 30 días.
+     * Idempotente: si la empresa ya tiene una promo de bienvenida, no crea otra.
+     */
+    async otorgarBienvenida(empresaId: number): Promise<Promocion | null> {
+        const yaTiene = await this.promoRepo.findOne({
+            where: { empresa: { id: empresaId }, origen: 'AUTO_REGISTRO' },
+        });
+        if (yaTiene) return null;
+
+        const inicio = new Date();
+        const fin = new Date(inicio);
+        fin.setDate(fin.getDate() + DIAS_BIENVENIDA);
+
+        const promo = this.promoRepo.create({
+            empresa: { id: empresaId } as any,
+            tipoAviso: TIPO_BIENVENIDA,
+            cantidad: CANTIDAD_BIENVENIDA,
+            cantidad_usada: 0,
+            fecha_inicio: inicio,
+            fecha_fin: fin,
+            origen: 'AUTO_REGISTRO',
+            otorgada_por: null,
+            motivo: 'Regalo de bienvenida',
+        });
+
+        return this.promoRepo.save(promo);
+    }
+
+    /**
+     * ➖ Consume 1 cupo de una promo vigente del tipo dado, si existe.
+     * Vigente = dentro de [fecha_inicio, fecha_fin] y con saldo (cantidad - cantidad_usada > 0).
+     * FIFO: usa primero la que vence antes.
+     * @returns la Promocion consumida; null si no había promo aplicable.
+     */
+    async consumirSiVigente(
+        empresaId: number,
+        tipoAviso: 'BASICO' | 'ESTANDAR' | 'PREMIUM',
+    ): Promise<Promocion | null> {
+        const ahora = new Date();
+
+        const candidatas = await this.promoRepo.find({
+            where: {
+                empresa: { id: empresaId },
+                tipoAviso,
+                fecha_inicio: LessThanOrEqual(ahora),
+                fecha_fin: MoreThan(ahora),
+            },
+            order: { fecha_fin: 'ASC' },
+        });
+
+        const promo = candidatas.find(
+            (p) => p.cantidad - p.cantidad_usada > 0,
+        );
+        if (!promo) return null;
+
+        promo.cantidad_usada += 1;
+        return this.promoRepo.save(promo);
+    }
+
+    /**
+     * 🔍 Promociones vigentes con saldo (para mostrar en disponibilidad).
+     */
+    async getVigentes(empresaId: number): Promise<Promocion[]> {
+        const ahora = new Date();
+
+        const promos = await this.promoRepo.find({
+            where: {
+                empresa: { id: empresaId },
+                fecha_inicio: LessThanOrEqual(ahora),
+                fecha_fin: MoreThan(ahora),
+            },
+            order: { fecha_fin: 'ASC' },
+        });
+
+        return promos.filter((p) => p.cantidad - p.cantidad_usada > 0);
+    }
+}

--- a/src/modules/stock/stock.controller.ts
+++ b/src/modules/stock/stock.controller.ts
@@ -9,8 +9,6 @@ export class StockController {
     // 🔍 Obtener créditos disponibles por empresa
     @Get('empresa/:empresaId')
     @UseGuards(AuthGuard('jwt'))
-    @Get('empresa/:empresaId')
-    @UseGuards(AuthGuard('jwt'))
     async getStockByEmpresa(@Param('empresaId') empresaId: number) {
         const fullStock = await this.stockService.getFullAvailability(empresaId);
 
@@ -20,6 +18,17 @@ export class StockController {
             pagados: fullStock.pagados.map((s) => ({
                 tipoAviso: s.tipoAviso,
                 cantidad_disponible: s.cantidad_disponible,
+            })),
+            promociones: fullStock.promociones.map((p) => ({
+                id: p.id,
+                tipoAviso: p.tipoAviso,
+                cantidad: p.cantidad,
+                cantidad_usada: p.cantidad_usada,
+                saldo: p.cantidad - p.cantidad_usada,
+                fecha_inicio: p.fecha_inicio,
+                fecha_fin: p.fecha_fin,
+                origen: p.origen,
+                motivo: p.motivo,
             })),
         };
     }

--- a/src/modules/stock/stock.module.ts
+++ b/src/modules/stock/stock.module.ts
@@ -8,10 +8,12 @@ import { TransactionItem } from 'src/repository/transaction_items/transaction-it
 import { StockController } from './stock.controller';
 import { StockGratis } from 'src/repository/free_stock/free-stock.entity';
 import { FreeStockService } from 'src/modules/stock/free-stock.service';
+import { PromocionModule } from 'src/modules/promocion/promocion.module';
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([Stock, Transaction, TransactionItem, StockGratis]),
+        PromocionModule,
     ],
     providers: [
         StockService,

--- a/src/modules/stock/stock.service.ts
+++ b/src/modules/stock/stock.service.ts
@@ -7,6 +7,8 @@ import { Transaction } from '../../repository/transaction/transaction.entity';
 import { TransactionItem } from '../../repository/transaction_items/transaction-items.entity';
 import { StockGratis } from 'src/repository/free_stock/free-stock.entity';
 import { FreeStockService } from 'src/modules/stock/free-stock.service';
+import { PromocionService } from 'src/modules/promocion/promocion.service';
+import { Promocion } from 'src/repository/promocion/promocion.entity';
 @Injectable()
 export class StockService {
     constructor(
@@ -20,6 +22,8 @@ export class StockService {
         private readonly itemRepo: Repository<TransactionItem>,
 
         public readonly freeStockService: FreeStockService,
+
+        private readonly promocionService: PromocionService,
     ) { }
 
     /**
@@ -90,12 +94,13 @@ export class StockService {
     }
 
     /**
-     * ➖ Usa un crédito de un tipo específico
+     * ➖ Usa un crédito de un tipo específico.
+     * @returns objeto con la promoción consumida (si la hubo) y el origen del crédito.
      */
     async useCredit(
         empresaId: number,
         tipoAviso: 'GRATIS' | 'BASICO' | 'ESTANDAR' | 'PREMIUM',
-    ) {
+    ): Promise<{ promocion: Promocion | null; origen: 'GRATIS' | 'PROMOCION' | 'PAGADO' }> {
         tipoAviso = tipoAviso.toUpperCase() as any;
 
         // 📌 1) Si el aviso es GRATIS → usar lógica de stock gratuito
@@ -107,10 +112,17 @@ export class StockService {
                 throw new Error(result.mensaje);
             }
 
-            return result.stock;
+            return { promocion: null, origen: 'GRATIS' };
         }
 
-        // 📌 2) Avisos pagados → lógica actual (NO se toca)
+        // 📌 2) Promoción vigente → consume primero el regalo antes que el stock pagado
+        const promoUsada = await this.promocionService.consumirSiVigente(empresaId, tipoAviso);
+        if (promoUsada) {
+            console.log(`🎁 Crédito ${tipoAviso} consumido desde promoción vigente (id=${promoUsada.id})`);
+            return { promocion: promoUsada, origen: 'PROMOCION' };
+        }
+
+        // 📌 3) Avisos pagados → lógica actual (NO se toca)
         const stock = await this.stockRepo.findOne({
             where: { empresa: { id: empresaId }, tipoAviso },
         });
@@ -128,9 +140,9 @@ export class StockService {
         }
 
         stock.cantidad_disponible -= 1;
-        const saved = await this.stockRepo.save(stock);
+        await this.stockRepo.save(stock);
 
-        return saved;
+        return { promocion: null, origen: 'PAGADO' };
     }
 
 
@@ -151,8 +163,9 @@ export class StockService {
     async getFullAvailability(empresaId: number) {
         const pagados = await this.getAvailability(empresaId);
         const gratis = await this.freeStockService.getMonthlyFreeStock(empresaId);
+        const promociones = await this.promocionService.getVigentes(empresaId);
 
-        return { gratis, pagados };
+        return { gratis, pagados, promociones };
     }
 }
 

--- a/src/modules/webpay+/webpay.service.ts
+++ b/src/modules/webpay+/webpay.service.ts
@@ -183,6 +183,7 @@ export class WebpayService {
     // ==============================================================
     async reconcileOrphanedTransactions() {
         const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000)
+        const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
 
         const orphaned = await this.transactionRepository
             .createQueryBuilder('t')
@@ -203,6 +204,19 @@ export class WebpayService {
                 const mappedStatus = mapPaymentStatus(wpStatus.status)
                 tx.response_data = wpStatus
                 tx.status = mappedStatus
+
+                // Timeout duro: si lleva >24h sin avanzar a PAGADA, cerrar como FALLIDA
+                // para que el cron deje de consultarla indefinidamente.
+                if (
+                    mappedStatus === TransactionStatus.PENDIENTE &&
+                    tx.createdAt < twentyFourHoursAgo
+                ) {
+                    tx.status = TransactionStatus.FALLIDA
+                    await this.transactionRepository.save(tx)
+                    console.log(`⏱️ Transacción ${tx.orderId} expirada por timeout (>24h)`)
+                    continue
+                }
+
                 await this.transactionRepository.save(tx)
 
                 if (mappedStatus === TransactionStatus.PAGADA && !tx.stock_processed) {

--- a/src/repository/job_offer/job-offer.entity.ts
+++ b/src/repository/job_offer/job-offer.entity.ts
@@ -15,6 +15,7 @@ import { Empresa } from '../business/business.entity';
 import { Empleador } from '../employer/employer.entity';
 import { CountVisit } from '../count_visits/count-visits.entity';
 import { DataOfertaDto } from 'src/modules/oferta/dto/create-oferta.dto';
+import { Promocion } from '../promocion/promocion.entity';
 
 @Entity('oferta')
 export class Oferta {
@@ -89,18 +90,27 @@ export class Oferta {
     @JoinColumn({ name: 'modificada_por' })
     modificada_por: Empleador;
 
+    // 🎁 Si la oferta consumió un cupo de una promoción, queda vinculada acá.
+    @ManyToOne(() => Promocion, { nullable: true, onDelete: 'SET NULL' })
+    @JoinColumn({ name: 'promocion_id' })
+    promocion: Promocion | null;
+
     // Calculada: fecha_publicacion + duracion_publicacion (días). No se persiste.
     fecha_expiracion?: Date | null;
+
+    // Derivado: true si la oferta vino de una promoción.
+    es_promocional?: boolean;
 
     @AfterLoad()
     computeFechaExpiracion() {
         if (!this.fecha_publicacion) {
             this.fecha_expiracion = null;
-            return;
+        } else {
+            const dias = this.duracion_publicacion ?? 30;
+            const d = new Date(this.fecha_publicacion);
+            d.setDate(d.getDate() + dias);
+            this.fecha_expiracion = d;
         }
-        const dias = this.duracion_publicacion ?? 30;
-        const d = new Date(this.fecha_publicacion);
-        d.setDate(d.getDate() + dias);
-        this.fecha_expiracion = d;
+        this.es_promocional = !!this.promocion;
     }
 }

--- a/src/repository/promocion/promocion.entity.ts
+++ b/src/repository/promocion/promocion.entity.ts
@@ -1,0 +1,59 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    JoinColumn,
+    CreateDateColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { Empresa } from '../business/business.entity';
+
+@Entity('promocion')
+export class Promocion {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => Empresa)
+    @JoinColumn({ name: 'empresa_id' })
+    empresa: Empresa;
+
+    @Column({
+        type: 'enum',
+        enum: ['BASICO', 'ESTANDAR', 'PREMIUM'],
+        default: 'PREMIUM',
+    })
+    tipoAviso: 'BASICO' | 'ESTANDAR' | 'PREMIUM';
+
+    @Column({ type: 'int', default: 3 })
+    cantidad: number;
+
+    @Column({ type: 'int', default: 0 })
+    cantidad_usada: number;
+
+    @Column({ type: 'datetime' })
+    fecha_inicio: Date;
+
+    @Column({ type: 'datetime' })
+    fecha_fin: Date;
+
+    @Column({
+        type: 'enum',
+        enum: ['AUTO_REGISTRO', 'EJECUTIVO'],
+        default: 'AUTO_REGISTRO',
+    })
+    origen: 'AUTO_REGISTRO' | 'EJECUTIVO';
+
+    // userId de quien otorgó la promo; null = otorgada por el sistema
+    @Column({ type: 'int', nullable: true })
+    otorgada_por: number | null;
+
+    @Column({ type: 'varchar', length: 500, nullable: true })
+    motivo: string | null;
+
+    @CreateDateColumn({ name: 'created_at' })
+    created_at: Date;
+
+    @UpdateDateColumn({ name: 'updated_at' })
+    updated_at: Date;
+}


### PR DESCRIPTION
Promo de bienvenida (empresa nueva):
- Nueva entidad Promocion (empresa, tipoAviso, cantidad, fechas, origen, otorgada_por)
- PromocionService: otorgarBienvenida (idempotente), consumirSiVigente (FIFO), getVigentes
- Hook automatico al crear empresa: 3 PREMIUM x 30 dias

Atribucion oferta -> promocion:
- FK Promocion nullable en Oferta + flag derivado es_promocional
- useCredit retorna {promocion, origen}, OfertaService asocia la promo a la oferta
- StockController expone promociones vigentes en GET /v1/stock/empresa/:id

Otros:
- Webpay: marcar como FALLIDA transacciones huerfanas con +24h sin pagar
- Validacion +56XXXXXXXXX (12 chars) en DTOs de telefono: business, postulante, empleador
- OAuth: agregar tuvacante.com al allowlist de origenes permitidos